### PR TITLE
Fix error when sending more than 15 requests  

### DIFF
--- a/PyMultiDictionary/_dictionary.py
+++ b/PyMultiDictionary/_dictionary.py
@@ -143,7 +143,7 @@ class MultiDictionary(object):
         _CACHED_SOUPS[link] = bs
         if len(bs_keys) >= self._max_cached_websites:
             # noinspection PyTypeChecker
-            del _CACHED_SOUPS[bs[0]]
+            del _CACHED_SOUPS[bs_keys[0]]
         return bs
 
     def _save_bsoup(self, link: str, filename: str, encoding: str = 'utf-8') -> None:

--- a/test/test_dictionary.py
+++ b/test/test_dictionary.py
@@ -268,6 +268,21 @@ class DictionaryTest(unittest.TestCase):
         # Test invalid dictionary
         # self.assertRaises(InvalidDictionary, lambda: d.antonym('es', 'word', dictionary=DICT_SYNONYMCOM))
 
+    def test_overwrite_cache(self) -> None:
+        """
+        Test request with maxed out cache.
+        """
+        d = self._get_dictionary('words', 'are', 'super', 'fun')
+        d.set_words_lang('en')
+        d._max_cached_websites = 3
+
+        self.assertEqual(len(d.get_synonyms()), 4)
+        self.assertEqual(len(d.get_synonyms(dictionary=DICT_EDUCALINGO)), 4)
+        self.assertEqual(len(d.get_synonyms(dictionary=DICT_SYNONYMCOM)), 4)
+        self.assertEqual(len(d.get_synonyms(dictionary=DICT_THESAURUS)), 4)
+        self.assertEqual(len(d.get_meanings(dictionary=DICT_WORDNET)), 4)
+
+
     def test_language_name(self) -> None:
         """
         Test language name.


### PR DESCRIPTION

# Description of Issue

`KeyError: 0` is returned if the program tries to get data from more than 15 webpages.

 ```python
from PyMultiDictionary import MultiDictionary, DICT_EDUCALINGO

# Error when calling meanings or synonyms for more than 15 words individually
dictionary1 = MultiDictionary()
wordlist = ['these', 'are', 'the', 'first', 'sixteen', 'words', 'i', 'could', 'come', 'up', 'with', 'to', 'use', 'for', 'this', 'example']
for word in wordlist:
  print(dictionary1.meaning('en', word)) # prints successfully until the 16th word, then throws KeyError

# Error when making a fixed dictionary instance with more than 15 words and calling meanings or synonyms as a group
dictionary2 = MultiDictionary('these', 'are', 'the', 'first', 'sixteen', 'words', 'i', 'could', 'come', 'up', 'with', 'to', 'use', 'for', 'this', 'example')
dictionary2.set_words_lang('en')
dictionary2.get_meanings(dictionary=DICT_EDUCALINGO) # throws KeyError
```
Here is the full traceback:
![image](https://user-images.githubusercontent.com/95894596/220208679-d5afc9b5-916a-4315-bb20-43ce95a71456.png)

It looks like the line that is supposed to delete a page from the _CACHED_SOUPS dictionary passes a key that doesn't exist.

# Fix

Change `del _CACHED_SOUPS[bs[0]]` to `del _CACHED_SOUPS[bs_keys[0]]` to delete the first cached webpage in the _CACHED_SOUPS dictionary. `bs_keys` is a list of the keys in the  _CACHED_SOUPS dictionary.

# Testing

As far as I can tell, it has fixed the issue. I am not very familiar with Python testing but I will work on adding cache tests to the test suite and try to have that done in the next few days.
